### PR TITLE
Docs fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Don't see what you're looking for?  DaaB is a generic event publisher, so create
 - Percentage
 - Statistics (list of name/value pairs)
 
-For more details see the [event setup wiki.](https://github.com/FordLabs/data-as-a-board/docs/Event-Types.md)
+For more details see the [event setup wiki.](https://github.com/FordLabs/data-as-a-board/blob/master/docs/Event-Types.md)
 
 ### Configuration
 
@@ -43,7 +43,7 @@ You can tell DaaB which event sources are active and which events are displayed 
 
 Additionally, all credentials necessary to access any APIs will be located here. 
 
-Refer to the [Configuring Events page](https://github.com/FordLabs/data-as-a-board/docs/Configuring-Events.md) for example application.yml files and instructions.
+Refer to the [Configuring Events page](https://github.com/FordLabs/data-as-a-board/blob/master/docs/Configuring-Events.md) for example application.yml files and instructions.
 
 ### Running locally for development
 

--- a/README.md
+++ b/README.md
@@ -34,9 +34,8 @@ Don't see what you're looking for?  DaaB is a generic event publisher, so create
 - Figure (value, subtext)
 - Percentage
 - Statistics (list of name/value pairs)
-<!-- commented out until wiki is migrated
-For more details see the [event setup wiki.](https://github.ford.com/FordLabs/data-as-a-board/wiki)
--->
+
+For more details see the [event setup wiki.](https://github.com/FordLabs/data-as-a-board/docs/Event-Types.md)
 
 ### Configuration
 
@@ -44,9 +43,7 @@ You can tell DaaB which event sources are active and which events are displayed 
 
 Additionally, all credentials necessary to access any APIs will be located here. 
 
-<!-- commented out until wiki is migrated
-Refer to the [Configuring Events page](https://github.ford.com/FordLabs/data-as-a-board/wiki/Configuring-Events) for example application.yml files and instructions.
--->
+Refer to the [Configuring Events page](https://github.com/FordLabs/data-as-a-board/docs/Configuring-Events.md) for example application.yml files and instructions.
 
 ### Running locally for development
 
@@ -66,5 +63,5 @@ You should use the development UI (running on port 3000) instead of the producti
 ### Building for production
 
 You can build a production jar (that includes the sample radiator application) by running the Gradle `build` task. 
-This will place a jar at `service/build/libs`.
+This will place a `data-as-a-board` jar at `service/build/libs`.  This jar can be deployed to a provider of choice.
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Redis is required to run DaaB locally, so ensure you have a Redis instance runni
 
 Once Redis is installed and running you can start DaaB with the Gradle `:bootRun` task. 
 
-This starts both the DaaB service and a development radiator running on ```http://localhost:3000```
+This starts both the DaaB service and a development radiator running on ```http://localhost:8080```
 
 If you would like to run the backend and frontend separately, use the `service:bootRun` and `ui:start` Gradle tasks.
 

--- a/docs/Configuring-Events.md
+++ b/docs/Configuring-Events.md
@@ -1,0 +1,62 @@
+# Application.yml configuration file
+
+For a sample application.yml file, see [here](https://github.com/FordLabs/data-as-a-board/blob/master/service/src/main/resources/application-sample.yml)
+
+There are two sections, `event` and `radiator`.  Each is discussed below.
+
+## Event Section
+
+Tell DaaB what events to consume in a declarative way.  Subsections such as `list` and `quote` correspond to event types.  Under each event type, declare events that will be consumed and give the event an identifier.  
+
+This section is only for events that have built in integrations.  DaaB reads this section to integrate with the third party services.  You will need to provide necessary consumption details, like keys/tokens, etc.  For example, to consume the health of our PCF EDC foundation as an event, provide the URL to check:
+
+```
+health:
+  applications:
+    - id: pcfprod
+      name: PCF EDC1 (Prod),
+      url: https://api.sys.pd01.edc1.cf.ford.com/v2/info
+```
+
+Many built-in integrations have example configurations in the sample file.
+
+### Custom Events
+
+DaaB supports publishing custom events for any event type.
+
+To publish custom events, you first need to register the event with DaaB to create an event id and get an event key.  The key prevents unauthorized event submissions to your event's identifier.
+
+#### Event Registration
+
+```
+POST
+{daab.url}/endpoint/register
+{
+   "id": <your event id as a string>
+}
+
+Response:
+{
+   "key": <secret event key, tied to event id>
+}
+```
+
+#### Event Publishing
+
+Now that you have your event id and event key, publish any event by making a rest request:
+
+```
+POST
+Headers:  "X-Event-Key": <your key>
+{daab.url}/endpoint/publish
+{
+   "id": <your event id as a string>,
+   "time": <time as an ISO compliant string>,
+   "eventType": <can be QUOTE, LIST, etc - see [here](https://github.ford.com/FordLabs/data-as-a-board/wiki)>,
+   "name": <name for the event - this will show up on the radiator>
+   <more event type specific properties here, ex. for quote, include "quote" and "author" as strings>
+}
+
+Response:
+200 OK
+```

--- a/docs/Event-Types.md
+++ b/docs/Event-Types.md
@@ -1,0 +1,44 @@
+# Data as a Board Wiki
+
+## Terminology
+* **Event** - A piece of data representing a condition at some timestamp. Events are the basic representation of all data passed through Data as a Board. There are specializations of Event, such as JobEvent or HealthEvent, that represent more concrete situations.
+
+* **Publisher** - A source of Events that publishes events to subscribers of Data Board. 
+
+* **Subscriber** - A sink of Events that listens to Data Board for either all or specific events.
+
+
+## Event Types
+* **JobEvent** - An event representing the state of a remotely executed job, such as those on a continuous integration server.
+
+  _Publishers_:
+    * JenkinsJobPublisher
+
+
+* **HealthEvent** - An event representing the state of a running application (UP/DOWN). 
+
+  _Publishers_:
+    * SpringHealthPublisher
+    * GenericHealthPublisher
+
+
+* **StatisticsEvent** - An event representing a set of statistics (key/value pairs).
+
+* **FigureEvent** - An event representing a figure (small string or numerical value).
+
+* **PercentageEvent** - An event representing a percentage.
+
+* **ListEvent** - An event representing a list of items or a list of lists
+
+  _Publishers_:
+    * RetroQuestActionItemsPublisher
+
+* **WeatherEvent** - An event representing weather data (temperature, conditions)
+  
+  _Publishers_:
+    * WeatherPublisher
+
+* **QuoteEvent** - An event representing a quote (text, author)
+
+  _Publishers_:
+    * UpwisePublisher


### PR DESCRIPTION
This PR migrates the wiki pages, I was looking for them on the public repo and didn't find them there, so I thought I would just go ahead and migrate them over.

I know that UI is now configurable via the UI itself and that's at least partially done, so I deleted the radiator config section from the wiki doc.